### PR TITLE
Return Failed ProgressEvent with error code for Integration tests

### DIFF
--- a/aws-macie-findingsfilter/src/test/java/software/amazon/macie/findingsfilter/CreateHandlerTest.java
+++ b/aws-macie-findingsfilter/src/test/java/software/amazon/macie/findingsfilter/CreateHandlerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 import static software.amazon.macie.findingsfilter.BaseMacieFindingFilterHandler.FILTER_ALREADY_EXISTS;
 import static software.amazon.macie.findingsfilter.BaseMacieFindingFilterHandler.MACIE_NOT_ENABLED;
+import static software.amazon.macie.findingsfilter.BaseMacieFindingFilterHandler.RESOURCE_EXISTS_CFN_MESSAGE;
 import static software.amazon.macie.findingsfilter.CreateHandler.OPERATION;
 
 import com.google.common.collect.ImmutableList;
@@ -49,7 +50,6 @@ public class CreateHandlerTest {
     private static final String ACCOUNT_ID = "accountId";
     private static final String MACIE_NOT_ENABLED_HTTP_STATUS_CODE = "403";
     private static final String FILTER_ALREADY_EXISTS_HTTP_STATUS_CODE = "400";
-    private static final String RESOURCE_EXISTS_CFN_MESSAGE = "Resource of type '%s' with identifier '%s' already exists.";
     private static final String ACCESS_DENIED_CFN_MESSAGE = "Access denied for operation '%s'.";
 
     private final ResourceModel model = ResourceModel.builder()
@@ -157,7 +157,7 @@ public class CreateHandlerTest {
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
         assertThat(response.getMessage()).contains(String.format(RESOURCE_EXISTS_CFN_MESSAGE, ResourceModel.TYPE_NAME, model.getName()));
-        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InternalFailure);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.AlreadyExists);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModels()).isNull();
     }

--- a/aws-macie-findingsfilter/src/test/java/software/amazon/macie/findingsfilter/DeleteHandlerTest.java
+++ b/aws-macie-findingsfilter/src/test/java/software/amazon/macie/findingsfilter/DeleteHandlerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static software.amazon.macie.findingsfilter.BaseMacieFindingFilterHandler.MACIE_NOT_ENABLED;
+import static software.amazon.macie.findingsfilter.BaseMacieFindingFilterHandler.RESOURCE_MISSING_CFN_MESSAGE;
 import static software.amazon.macie.findingsfilter.DeleteHandler.OPERATION;
 
 import java.time.Duration;
@@ -36,7 +37,6 @@ public class DeleteHandlerTest {
     private static final String MACIE_NOT_ENABLED_HTTP_STATUS_CODE = "403";
     private static final String FILTER_MISSING_HTTP_STATUS_CODE = "404";
     private static final String FILTER_MISSING_MACIE_MESSAGE = "Resource not found. Verify any provided IDs are correct.";
-    private static final String RESOURCE_MISSING_CFN_MESSAGE = "Resource of type '%s' with identifier '%s' was not found.";
     private static final String ACCESS_DENIED_CFN_MESSAGE = "Access denied for operation '%s'.";
 
     private final ResourceModel model = ResourceModel.builder()
@@ -104,7 +104,7 @@ public class DeleteHandlerTest {
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
         assertThat(response.getMessage()).contains(String.format(RESOURCE_MISSING_CFN_MESSAGE, ResourceModel.TYPE_NAME, model.getFilterId()));
-        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InternalFailure);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.NotFound);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModels()).isNull();
     }

--- a/aws-macie-findingsfilter/src/test/java/software/amazon/macie/findingsfilter/ReadHandlerTest.java
+++ b/aws-macie-findingsfilter/src/test/java/software/amazon/macie/findingsfilter/ReadHandlerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static software.amazon.macie.findingsfilter.BaseMacieFindingFilterHandler.MACIE_NOT_ENABLED;
+import static software.amazon.macie.findingsfilter.BaseMacieFindingFilterHandler.RESOURCE_MISSING_CFN_MESSAGE;
 import static software.amazon.macie.findingsfilter.ReadHandler.OPERATION;
 
 import com.google.common.collect.ImmutableList;
@@ -45,7 +46,6 @@ public class ReadHandlerTest {
     private static final String MACIE_NOT_ENABLED_HTTP_STATUS_CODE = "403";
     private static final String FILTER_MISSING_HTTP_STATUS_CODE = "404";
     private static final String FILTER_MISSING_MACIE_MESSAGE = "Resource not found. Verify any provided IDs are correct.";
-    private static final String RESOURCE_MISSING_CFN_MESSAGE = "Resource of type '%s' with identifier '%s' was not found.";
     private static final String ACCESS_DENIED_CFN_MESSAGE = "Access denied for operation '%s'.";
 
     private final ResourceModel model = ResourceModel.builder()
@@ -141,7 +141,7 @@ public class ReadHandlerTest {
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
         assertThat(response.getMessage()).contains(String.format(RESOURCE_MISSING_CFN_MESSAGE, ResourceModel.TYPE_NAME, model.getFilterId()));
-        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InternalFailure);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.NotFound);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModels()).isNull();
     }

--- a/aws-macie-findingsfilter/src/test/java/software/amazon/macie/findingsfilter/UpdateHandlerTest.java
+++ b/aws-macie-findingsfilter/src/test/java/software/amazon/macie/findingsfilter/UpdateHandlerTest.java
@@ -7,6 +7,8 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 import static software.amazon.macie.findingsfilter.BaseMacieFindingFilterHandler.FILTER_ALREADY_EXISTS;
 import static software.amazon.macie.findingsfilter.BaseMacieFindingFilterHandler.MACIE_NOT_ENABLED;
+import static software.amazon.macie.findingsfilter.BaseMacieFindingFilterHandler.RESOURCE_EXISTS_CFN_MESSAGE;
+import static software.amazon.macie.findingsfilter.BaseMacieFindingFilterHandler.RESOURCE_MISSING_CFN_MESSAGE;
 import static software.amazon.macie.findingsfilter.UpdateHandler.OPERATION;
 
 import com.google.common.collect.ImmutableList;
@@ -51,8 +53,6 @@ public class UpdateHandlerTest {
     private static final String FILTER_ALREADY_EXISTS_HTTP_STATUS_CODE = "400";
     private static final String FILTER_MISSING_HTTP_STATUS_CODE = "404";
     private static final String FILTER_MISSING_MACIE_MESSAGE = "Resource not found. Verify any provided IDs are correct.";
-    private static final String RESOURCE_MISSING_CFN_MESSAGE = "Resource of type '%s' with identifier '%s' was not found.";
-    private static final String RESOURCE_EXISTS_CFN_MESSAGE = "Resource of type '%s' with identifier '%s' already exists.";
     private static final String ACCESS_DENIED_CFN_MESSAGE = "Access denied for operation '%s'.";
 
     private final ResourceModel model = ResourceModel.builder()
@@ -160,7 +160,7 @@ public class UpdateHandlerTest {
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
         assertThat(response.getMessage()).contains(String.format(RESOURCE_MISSING_CFN_MESSAGE, ResourceModel.TYPE_NAME, model.getFilterId()));
-        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InternalFailure);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.NotFound);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModels()).isNull();
     }
@@ -187,7 +187,7 @@ public class UpdateHandlerTest {
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
         assertThat(response.getMessage()).contains(String.format(RESOURCE_EXISTS_CFN_MESSAGE, ResourceModel.TYPE_NAME, model.getName()));
-        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InternalFailure);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.AlreadyExists);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModels()).isNull();
     }

--- a/aws-macie-session/src/main/java/software/amazon/macie/session/BaseMacieSessionHandler.java
+++ b/aws-macie-session/src/main/java/software/amazon/macie/session/BaseMacieSessionHandler.java
@@ -1,12 +1,16 @@
 package software.amazon.macie.session;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.http.HttpStatus;
 import software.amazon.awssdk.services.macie2.Macie2Client;
-import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
+import software.amazon.awssdk.services.macie2.model.Macie2Exception;
 import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
-import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProgressEvent.ProgressEventBuilder;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
@@ -16,6 +20,10 @@ public abstract class BaseMacieSessionHandler extends BaseHandler<CallbackContex
     // Error code being 403, we can't depend on error code for this.
     protected final static String MACIE_NOT_ENABLED = "Macie is not enabled";
     protected final static String MACIE_ALREADY_ENABLED = "Macie has already been enabled";
+    protected static final String MACIE_ALREADY_ENABLED_EXPECTED_MESSAGE = "Resource of type '%s' with identifier '%s' already exists.";
+    protected static final String MACIE_NOT_ENABLED_EXPECTED_MESSAGE = "Resource of type '%s' with identifier '%s' was not found.";
+    private final static String RETRY_MESSAGE = "Detected retryable error, retrying. Exception message: %s";
+    private final static String EXCEPTION_MESSAGE = "Exception occurred. Exception message: %s";
 
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(AmazonWebServicesClientProxy proxy,
@@ -35,11 +43,33 @@ public abstract class BaseMacieSessionHandler extends BaseHandler<CallbackContex
         ProxyClient<Macie2Client> proxyClient,
         Logger logger);
 
-    public ProgressEvent<ResourceModel, CallbackContext> handleError(final String operation, final Exception exception, final ResourceModel model) {
+    private Boolean retryError(Exception exception) {
+        return exception instanceof Macie2Exception
+            && ((Macie2Exception) exception).awsErrorDetails().sdkHttpResponse().statusCode() == HttpStatus.SC_INTERNAL_SERVER_ERROR;
+    }
+
+    public ProgressEvent<ResourceModel, CallbackContext> handleError(final String operation, final Exception exception, final ResourceModel model,
+        CallbackContext context, Logger logger) {
+        // All InternalServerExceptions are retryable
+        if (retryError(exception)) {
+            logger.log(String.format(RETRY_MESSAGE, exception.getMessage()));
+            return ProgressEvent.progress(model, context);
+        }
+
+        logger.log(String.format(EXCEPTION_MESSAGE, ExceptionUtils.getStackTrace(exception)));
+        ProgressEventBuilder<ResourceModel, CallbackContext> failureProgressEvent = ProgressEvent.<ResourceModel, CallbackContext>builder()
+            .resourceModel(model)
+            .status(OperationStatus.FAILED);
         if (exception.getMessage().contains(MACIE_NOT_ENABLED)) {
-            throw new CfnNotFoundException(model.TYPE_NAME, model.getAwsAccountId(), exception);
+            return failureProgressEvent
+                .errorCode(HandlerErrorCode.NotFound)
+                .message(String.format(MACIE_NOT_ENABLED_EXPECTED_MESSAGE, ResourceModel.TYPE_NAME, model.getAwsAccountId()))
+                .build();
         } else if (exception.getMessage().contains(MACIE_ALREADY_ENABLED)) {
-            throw new CfnAlreadyExistsException(model.TYPE_NAME, model.getAwsAccountId(), exception);
+            return failureProgressEvent
+                .errorCode(HandlerErrorCode.AlreadyExists)
+                .message(String.format(MACIE_ALREADY_ENABLED_EXPECTED_MESSAGE, ResourceModel.TYPE_NAME, model.getAwsAccountId()))
+                .build();
         } else {
             throw new CfnGeneralServiceException(operation, exception);
         }

--- a/aws-macie-session/src/main/java/software/amazon/macie/session/CreateHandler.java
+++ b/aws-macie-session/src/main/java/software/amazon/macie/session/CreateHandler.java
@@ -40,7 +40,7 @@ public class CreateHandler extends BaseMacieSessionHandler {
             // Ensure all requisite resources are created and we can query Macie session
             .stabilize(this::stabilize)
             // return appropriate failed progress event status by mapping business exceptions.
-            .handleError((_request, _exception, _client, _model, _context) -> handleError(OPERATION, _exception, _model))
+            .handleError((_request, _exception, _client, _model, _context) -> handleError(OPERATION, _exception, _model, _context, logger))
             // Once ACTIVE return progress
             .progress()
             // we then delegate to ReadHandler to read the live state and send back successful response.

--- a/aws-macie-session/src/main/java/software/amazon/macie/session/DeleteHandler.java
+++ b/aws-macie-session/src/main/java/software/amazon/macie/session/DeleteHandler.java
@@ -31,7 +31,7 @@ public class DeleteHandler extends BaseMacieSessionHandler {
             // Make a service call. Handler does not worry about credentials, they are auto injected
             .makeServiceCall((r, c) -> c.injectCredentialsAndInvokeV2(r, c.client()::disableMacie))
             // return appropriate failed progress event status by mapping business exceptions.
-            .handleError((_request, _exception, _client, _model, _context) -> handleError(OPERATION, _exception, _model))
+            .handleError((_request, _exception, _client, _model, _context) -> handleError(OPERATION, _exception, _model, _context, logger))
             // return success
             .done((_request, _response, _client, _model, _context) -> ProgressEvent.<ResourceModel, CallbackContext>builder()
                 .status(OperationStatus.SUCCESS)

--- a/aws-macie-session/src/main/java/software/amazon/macie/session/ReadHandler.java
+++ b/aws-macie-session/src/main/java/software/amazon/macie/session/ReadHandler.java
@@ -32,7 +32,7 @@ public class ReadHandler extends BaseMacieSessionHandler {
             // Make a service call. Handler does not worry about credentials, they are auto injected
             .makeServiceCall((r, c) -> c.injectCredentialsAndInvokeV2(r, c.client()::getMacieSession))
             // return appropriate failed progress event status by mapping business exceptions.
-            .handleError((_request, _exception, _client, _model, _context) -> handleError(OPERATION, _exception, _model))
+            .handleError((_request, _exception, _client, _model, _context) -> handleError(OPERATION, _exception, _model, _context, logger))
             // return success progress event with resource details
             .done(this::buildModelFromResponse);
     }

--- a/aws-macie-session/src/main/java/software/amazon/macie/session/UpdateHandler.java
+++ b/aws-macie-session/src/main/java/software/amazon/macie/session/UpdateHandler.java
@@ -33,7 +33,7 @@ public class UpdateHandler extends BaseMacieSessionHandler {
             // Make a service call. Handler does not worry about credentials, they are auto injected
             .makeServiceCall((r, c) -> c.injectCredentialsAndInvokeV2(r, c.client()::updateMacieSession))
             // return appropriate failed progress event status by mapping business exceptions.
-            .handleError((_request, _exception, _client, _model, _context) -> handleError(OPERATION, _exception, _model))
+            .handleError((_request, _exception, _client, _model, _context) -> handleError(OPERATION, _exception, _model, _context, logger))
             // Once ACTIVE return progress
             .progress()
             // we then delegate to ReadHandler to read the live state and send back successful response.

--- a/aws-macie-session/src/test/java/software/amazon/macie/session/CreateHandlerTest.java
+++ b/aws-macie-session/src/test/java/software/amazon/macie/session/CreateHandlerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 import static software.amazon.macie.session.BaseMacieSessionHandler.MACIE_ALREADY_ENABLED;
+import static software.amazon.macie.session.BaseMacieSessionHandler.MACIE_ALREADY_ENABLED_EXPECTED_MESSAGE;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -38,7 +39,6 @@ public class CreateHandlerTest {
 
     private static final Credentials MOCK_CREDENTIALS = new Credentials("accessKey", "secretKey", "token");
     private static final String MACIE_ALREADY_ENABLED_CODE = "409";
-    private static final String MACIE_ALREADY_ENABLED_EXPECTED_MESSAGE = "Resource of type '%s' with identifier '%s' already exists.";
     private static final String SERVICE_ROLE = "arn:%s:iam::%s:role/aws-service-role/macie.amazonaws.com/AWSServiceRoleForAmazonMacie";
     private static final String CLIENT_TOKEN = "CLIENT_TOKEN";
     private static final String TEST_ACCOUNT_ID = "999999999999";
@@ -129,7 +129,7 @@ public class CreateHandlerTest {
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
         assertThat(response.getMessage()).contains(String.format(MACIE_ALREADY_ENABLED_EXPECTED_MESSAGE, ResourceModel.TYPE_NAME, model.getAwsAccountId()));
-        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InternalFailure);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.AlreadyExists);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModels()).isNull();
     }

--- a/aws-macie-session/src/test/java/software/amazon/macie/session/DeleteHandlerTest.java
+++ b/aws-macie-session/src/test/java/software/amazon/macie/session/DeleteHandlerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static software.amazon.macie.session.BaseMacieSessionHandler.MACIE_NOT_ENABLED;
+import static software.amazon.macie.session.BaseMacieSessionHandler.MACIE_NOT_ENABLED_EXPECTED_MESSAGE;
 
 import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,7 +31,6 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 @ExtendWith(MockitoExtension.class)
 public class DeleteHandlerTest {
     private static final Credentials MOCK_CREDENTIALS = new Credentials("accessKey", "secretKey", "token");
-    private static final String MACIE_NOT_ENABLED_EXPECTED_MESSAGE = "Resource of type '%s' with identifier '%s' was not found.";
     private static final String MACIE_NOT_ENABLED_CODE = "403";
 
     @Mock
@@ -93,7 +93,7 @@ public class DeleteHandlerTest {
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
         assertThat(response.getMessage()).contains(String.format(MACIE_NOT_ENABLED_EXPECTED_MESSAGE, ResourceModel.TYPE_NAME, model.getAwsAccountId()));
-        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InternalFailure);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.NotFound);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModels()).isNull();
     }

--- a/aws-macie-session/src/test/java/software/amazon/macie/session/ReadHandlerTest.java
+++ b/aws-macie-session/src/test/java/software/amazon/macie/session/ReadHandlerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static software.amazon.macie.session.BaseMacieSessionHandler.MACIE_NOT_ENABLED;
+import static software.amazon.macie.session.BaseMacieSessionHandler.MACIE_NOT_ENABLED_EXPECTED_MESSAGE;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -33,7 +34,6 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 @ExtendWith(MockitoExtension.class)
 public class ReadHandlerTest {
     private static final Credentials MOCK_CREDENTIALS = new Credentials("accessKey", "secretKey", "token");
-    private static final String MACIE_NOT_ENABLED_EXPECTED_MESSAGE = "Resource of type '%s' with identifier '%s' was not found.";
     private static final String MACIE_NOT_ENABLED_CODE = "403";
     private static final String SERVICE_ROLE = "arn:%s:iam::%s:role/SERVICE-ROLE-NAME";
     private static final String TEST_ACCOUNT_ID = "999999999999";
@@ -119,7 +119,7 @@ public class ReadHandlerTest {
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
         assertThat(response.getMessage()).contains(String.format(MACIE_NOT_ENABLED_EXPECTED_MESSAGE, ResourceModel.TYPE_NAME, model.getAwsAccountId()));
-        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InternalFailure);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.NotFound);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModels()).isNull();
     }

--- a/aws-macie-session/src/test/java/software/amazon/macie/session/UpdateHandlerTest.java
+++ b/aws-macie-session/src/test/java/software/amazon/macie/session/UpdateHandlerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 import static software.amazon.macie.session.BaseMacieSessionHandler.MACIE_NOT_ENABLED;
+import static software.amazon.macie.session.BaseMacieSessionHandler.MACIE_NOT_ENABLED_EXPECTED_MESSAGE;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -37,7 +38,6 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 public class UpdateHandlerTest {
 
     private static final Credentials MOCK_CREDENTIALS = new Credentials("accessKey", "secretKey", "token");
-    private static final String MACIE_NOT_ENABLED_EXPECTED_MESSAGE = "Resource of type '%s' with identifier '%s' was not found.";
     private static final String MACIE_NOT_ENABLED_CODE = "403";
     private static final String SERVICE_ROLE = "arn:%s:iam::%s:role/SERVICE-ROLE-NAME";
     private static final String TEST_ACCOUNT_ID = "999999999999";
@@ -130,7 +130,7 @@ public class UpdateHandlerTest {
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
         assertThat(response.getMessage()).contains(String.format(MACIE_NOT_ENABLED_EXPECTED_MESSAGE, ResourceModel.TYPE_NAME, model.getAwsAccountId()));
-        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InternalFailure);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.NotFound);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModels()).isNull();
     }


### PR DESCRIPTION
*Description of changes:*
CFN is currently treating all Cfn* exceptions as failure, which contradicts with Integration tests. Until that is fixed, we will be constructing raw ProgressEvent objects with FAILED status and applicable error code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
